### PR TITLE
run_once only works if master[0] is first in inventory list of all nodes

### DIFF
--- a/roles/kubernetes/node/tasks/secrets.yml
+++ b/roles/kubernetes/node/tasks/secrets.yml
@@ -14,7 +14,6 @@
     group={{ kube_cert_group }}
 
 - include: gen_certs.yml
-  run_once: true
   when: inventory_hostname == groups['kube-master'][0]
 
 - include: gen_tokens.yml


### PR DESCRIPTION
I dynamically build my node list/inventory file.  This doesn't guarantee that the list of nodes is always the same or that master[0] is first in the all or cluster lists.

The run_once would prevent the certs from being made and later fail.
The when clause should effectively only make it run once.