### PR TITLE
Use 'ip' if specified, otherwise use the ansible discovered address.

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: populate inventory into hosts file
   lineinfile:
     dest: /etc/hosts
-    regexp: "^{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}$"
-    line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}"
+    regexp: "^{{ hostvars[item]['ip'] | default(hostvars[item].ansible_default_ipv4.address) }} {{ item }}$"
+    line: "{{ hostvars[item]['ip'] | default(hostvars[item].ansible_default_ipv4.address) }} {{ item }}"
     state: present
     backup: yes
   when: hostvars[item].ansible_default_ipv4.address is defined

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -27,6 +27,18 @@
   with_items:
     - '^127\.0\.0\.1(\s+){{ inventory_hostname }}.*'
     - '^::1(\s+){{ inventory_hostname }}.*'
+    - '^::1(\s+)localhost.*'
+    - '^127.0.0.1(\s+)localhost.*'
+
+- name: localhost in hosts file
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ item }}"
+    state: present
+    backup: yes
+  with_items:
+    - '127.0.0.1 localhost localhost.localdomain'
+    - '::1 localhost6 localhost6.localdomain'
 
 - name: ensure dnsmasq.d directory exists
   file:


### PR DESCRIPTION
This fixes cases for use in Vagrant environments or other multi-ip environments.