### PR TITLE
Use IP is specified, otherwise use the ansible discovered address.

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: populate inventory into hosts file
   lineinfile:
     dest: /etc/hosts
-    regexp: "^{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}$"
-    line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}"
+    regexp: "^{{ hostvars[item]['ip'] | default(hostvars[item].ansible_default_ipv4.address) }} {{ item }}$"
+    line: "{{ hostvars[item]['ip'] | default(hostvars[item].ansible_default_ipv4.address) }} {{ item }}"
     state: present
     backup: yes
   when: hostvars[item].ansible_default_ipv4.address is defined


### PR DESCRIPTION
This fixes cases for use in Vagrant environments.