### PR TITLE
Set update_cache to yes when installing the required dependencies

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -45,6 +45,7 @@
   action:
     module: "{{ ansible_pkg_mgr }}"
     name: "{{ item }}"
+    update_cache: yes
     state: latest
   with_items: "{{required_pkgs | union(common_required_pkgs)}}"
 


### PR DESCRIPTION
When trying to deploy on a fresh spawned VM on a cloud the distribution package repository (apt, yum...) cache is not necessary up to date. This can lead to an error when the preinstall role tries to install the required packages. It can be fixed by forcing a cache update.