### PR TITLE
Add flannel vars to enable vagrant and amazon environments

### DIFF
--- a/roles/network_plugin/templates/flannel/flannel-pod.yml
+++ b/roles/network_plugin/templates/flannel/flannel-pod.yml
@@ -31,7 +31,7 @@
         command:
           - "/bin/sh"
           - "-c"
-          - "/opt/bin/flanneld -etcd-endpoints {% for srv in groups['etcd'] %}http://{{ srv }}:2379{% if not loop.last %},{% endif %}{% endfor %} -etcd-prefix /{{ cluster_name }}/network 1>>/var/log/flannel_server.log 2>&1"
+          - "/opt/bin/flanneld -etcd-endpoints {% for srv in groups['etcd'] %}http://{{ srv }}:2379{% if not loop.last %},{% endif %}{% endfor %} -etcd-prefix /{{ cluster_name }}/network {% if flannel_interface is defined %}-iface {{ flannel_interface }}{% endif %} {% if flannel_public_ip is defined %}-public-ip {{ flannel_public_ip }}{% endif %} 1>>/var/log/flannel_server.log 2>&1"
         ports:
           - hostPort: 10253
             containerPort: 10253


### PR DESCRIPTION
In order to support environments where the first interface is not necessarily the outbound interface, add a flannel_interface to be specified per host (or globally) what interface should be used for flannel operations.  If unset, the original behavior will work.

In order to support environments where the public IP is not "known" to the host, but is the only way the node can be accessed, add a flannel_public_ip variable that defines the IP used to talk to the node in question.  This is useful for the Amazon case where nodes may not be aware of their public IP, but need to advertise how to get to them.