### PR TITLE
Force owner and permissions for get_url retrieved files.

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -14,8 +14,17 @@
 
 - name: Extract archives
   unarchive:
-     src: "{{ local_release_dir }}/{{item.dest}}"
-     dest: "{{ local_release_dir }}/{{item.dest|dirname}}"
-     copy: no
+    src: "{{ local_release_dir }}/{{item.dest}}"
+    dest: "{{ local_release_dir }}/{{item.dest|dirname}}"
+    copy: no
   when: "{{item.unarchive is defined and item.unarchive == True}}"
+  with_items: downloads
+
+- name: Fix permissions
+  file:
+    state: file
+    path: "{{local_release_dir}}/{{item.dest}}"
+    owner: "{{ item.owner|default(omit) }}"
+    mode: "{{ item.mode|default(omit) }}"
+  when: "{{item.unarchive is not defined or item.unarchive == False}}"
   with_items: downloads


### PR DESCRIPTION
get_url doesn't honor owner and mode is spotty.

I found that on ubuntu 14.04 with ansible 2.0.0.2 going to a centos 7 system.  The get_url call pull the files but didn't set the owner and sometimes set the mode.  I checked the docs and get_url doesn't appear to take owner and mode specifically (though the example shows mode).

Adding an explicit file call to make the mode and owner match the dictionary seems to work.