### PR TITLE
use 'kube_pods_subnet' var for flannel conf

### DIFF
--- a/roles/network_plugin/templates/flannel/network.json
+++ b/roles/network_plugin/templates/flannel/network.json
@@ -1,1 +1,1 @@
-{ "Network": "{{ kube_service_addresses }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "vxlan" } }
+{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "vxlan" } }


### PR DESCRIPTION
The pods ips have to be part of the `kube_pods_subnet`.