### PR TITLE
Update docker for CentOS issues in AWS and general variables

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -47,6 +47,15 @@
   with_items: docker_package_info.pkgs
   when: docker_package_info.pkgs|length > 0
 
+- name: Centos needs xfs storage type for devicemapper if used
+  lineinfile:
+    dest: /etc/sysconfig/docker-storage
+    line: "DOCKER_STORAGE_OPTIONS='--storage-opt dm.fs=xfs'"
+    regexp: '^DOCKER_STORAGE_OPTIONS=.*$'
+    state: present
+    backup: yes
+  when: ansible_os_family == "RedHat"
+
 - meta: flush_handlers
 
 - name: ensure docker service is started and enabled

--- a/roles/network_plugin/tasks/main.yml
+++ b/roles/network_plugin/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Set docker daemon options
   template:
     src: docker
-    dest: "/etc/default/docker"
+    dest: "{{ '/etc/sysconfig/docker-network' if ansible_os_family == 'RedHat' else '/etc/default/docker' }}"
     owner: root
     group: root
     mode: 0644

--- a/roles/network_plugin/templates/docker
+++ b/roles/network_plugin/templates/docker
@@ -1,6 +1,8 @@
 # Deployed by Ansible
 {% if init_system == "sysvinit" and kube_network_plugin == "flannel" and ansible_os_family == "Debian" %}
 DOCKER_OPTS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
+{% elif kube_network_plugin == "flannel" and ansible_os_family == "RedHat" %}
+DOCKER_NETWORK_OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
 {% elif kube_network_plugin == "flannel" %}
 OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"
 {% endif %}

--- a/roles/network_plugin/templates/systemd-docker.service
+++ b/roles/network_plugin/templates/systemd-docker.service
@@ -11,7 +11,13 @@ Requires=docker.socket
 
 [Service]
 Type=notify
+{% if ansible_os_family == "RedHat" %}
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-network
+EnvironmentFile=-/etc/sysconfig/docker-storage
+{% elif ansible_os_family == "Debian" %}
 EnvironmentFile=-/etc/default/docker
+{% endif %}
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/bin/docker daemon \
           $OPTIONS \


### PR DESCRIPTION

1. AWS has issues with ext4 (use xfs instead for CentOS only)
2. Make sure all the centos config files are include in the systemd config
3. Make sure that network options are set in the correct file by os family

This allows downstream items like opencontrail and others change variables
in expected locations.